### PR TITLE
Fix for RM 42047, Issue #39

### DIFF
--- a/hdfs_connection.c
+++ b/hdfs_connection.c
@@ -37,6 +37,7 @@ hdfs_get_connection(ForeignServer *server, UserMapping *user, hdfs_opt *opt)
 							opt->password,
 							opt->connect_timeout,
 							opt->receive_timeout,
+							opt->auth_type,
 							&err_buf);
 	if (conn < 0)
 		ereport(ERROR,

--- a/hdfs_fdw.h
+++ b/hdfs_fdw.h
@@ -71,6 +71,7 @@ typedef struct hdfs_opt
 	char           *dbname;           /* HDFS database name */
 	char           *table_name;       /* HDFS table name */
 	CLIENT_TYPE    client_type;
+	AUTH_TYPE      auth_type;
 	bool           use_remote_estimate;
 	int            connect_timeout;
 	int            receive_timeout;

--- a/libhive/jdbc/hiveclient.cpp
+++ b/libhive/jdbc/hiveclient.cpp
@@ -169,7 +169,7 @@ int Initialize()
 	}
 
 	g_DBOpenConnection = g_jni->GetMethodID(g_clsJdbcClient, "DBOpenConnection",
-				"(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IILMsgBuf;)I");
+				"(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILMsgBuf;)I");
 	if (g_DBOpenConnection == NULL)
 	{
 		g_jvm->DestroyJavaVM();
@@ -255,7 +255,7 @@ int Destroy()
 int DBOpenConnection(char *host, int port, char *databaseName,
 					char *username, char *password,
 					int connectTimeout, int receiveTimeout,
-					char **errBuf)
+					AUTH_TYPE auth_type, char **errBuf)
 {
 	int rc;
 	jstring rv;
@@ -276,6 +276,7 @@ int DBOpenConnection(char *host, int port, char *databaseName,
 							g_jni->NewStringUTF(password),
 							connectTimeout,
 							receiveTimeout,
+							auth_type,
 							g_objMsgBuf);
 
 	rv = (jstring)g_jni->CallObjectMethod(g_objMsgBuf, g_getVal);

--- a/libhive/jdbc/hiveclient.h
+++ b/libhive/jdbc/hiveclient.h
@@ -38,6 +38,13 @@ typedef enum HIVE_SERVER_TYPE {
   HIVE_SERVER2 =  1
 } HIVE_SERVER_TYPE;
 
+typedef enum AUTH_TYPE
+{
+	AUTH_TYPE_UNSPECIFIED = 0,
+	AUTH_TYPE_NOSASL,
+	AUTH_TYPE_LDAP
+} AUTH_TYPE;
+
 /******************************************************************************
  * Global Hive Client Functions (usable as C callback functions)
  *****************************************************************************/
@@ -85,7 +92,7 @@ int Destroy(void);
 int DBOpenConnection(char *host, int port, char *databaseName,
 					char *username, char *password,
 					int connectTimeout, int receiveTimeout,
-					char **errBuf);
+					AUTH_TYPE auth_type, char **errBuf);
 
 /**
  * @brief Disconnect from a Hive database.


### PR DESCRIPTION
Problem Statement:
The HDFS_FDW was inferring the authentication type
from the options of the CREATE USER MAPPING command
If it found that the username is empty, it concluded NOSASL
otherwise it concluded LDAP.
In case of NOSASL since the username was empty while
connecting to the hive server the FDW was specifying an
arbitrary username. While this technique worked for the rest
of the cases, it failed in case of ANALYZE.
ANALYZE needed an OS user that had write access to the
folder /tmp/hadoop-yarn

Solution:
Add another option in CREATE SERVER command, called the
auth_type. This option, which can be omitted, can have the
following values: NOSASL & LDAP
When specified a non empty username must be specified while
creating the user mapping.
When omitted the FDW tries to infer the auth_type from the options
of the user mapping, like it used to do.
Hence the FDW is backwards compatible and existing test cases
do not need any modification.

If auth_type is specified and a valid username is specified
that has write access to the folder /tmp/hadoop-yarn, then
ANALYZE works fine.

For Example:

postgres=# CREATE EXTENSION hdfs_fdw;
CREATE EXTENSION
postgres=# CREATE SERVER hdfs_svr FOREIGN DATA WRAPPER hdfs_fdw OPTIONS (host '127.0.0.1',port '10000',client_type 'hiveserver2', auth_type 'NOSASL');
CREATE SERVER
postgres=# CREATE USER MAPPING FOR abbasbutt server hdfs_svr OPTIONS (username 'abbasbutt', password '');
CREATE USER MAPPING
postgres=# CREATE FOREIGN TABLE fnt( a int, name varchar(255)) SERVER hdfs_svr OPTIONS (dbname 'testdb', table_name 'names_tab');
CREATE FOREIGN TABLE
postgres=# SELECT * FROM fnt;
 a | name
---+-------
 1 | abcd
 2 | pqrs
 3 | wxyz
 4 | a_b_c
 5 | p_q_r
   |
 1 | abcd
 2 | pqrs
 3 | wxyz
 4 | a_b_c
 5 | p_q_r
   |
(12 rows)

postgres=# ANALYZE fnt;
ANALYZE