### PR TITLE
Issue #46, Eliminate issues in HDFS_FDW to run TPC-H queries.

### DIFF
--- a/hdfs_connection.c
+++ b/hdfs_connection.c
@@ -44,7 +44,7 @@ hdfs_get_connection(ForeignServer *server, UserMapping *user, hdfs_opt *opt)
 			(errcode(ERRCODE_FDW_OUT_OF_MEMORY),
 				errmsg("failed to initialize the HDFS connection object (%s)", err_buf)));
 
-	ereport(DEBUG1, (errmsg("HDFS_FDW: connection opened %d", conn)));
+	ereport(DEBUG1, (errmsg("hdfs_fdw: connection opened %d", conn)));
 
 	return conn;
 }
@@ -63,5 +63,5 @@ hdfs_rel_connection(int con_index)
 			(errcode(ERRCODE_FDW_OUT_OF_MEMORY),
 				errmsg("failed to close HDFS connection object")));
 
-	ereport(DEBUG1, (errmsg("HDFS_FDW: connection closed %d", con_index)));
+	ereport(DEBUG1, (errmsg("hdfs_fdw: connection closed %d", con_index)));
 }

--- a/hdfs_option.c
+++ b/hdfs_option.c
@@ -74,6 +74,8 @@ static struct HDFSFdwOption valid_options[] =
 	{ "use_remote_estimate", ForeignServerRelationId },
 	{ "query_timeout",       ForeignServerRelationId },
 	{ "connect_timeout",     ForeignServerRelationId },
+	{ "fetch_size",          ForeignServerRelationId },
+	{ "log_remote_sql",      ForeignServerRelationId },
 	{ NULL,                  InvalidOid }
 };
 
@@ -168,6 +170,8 @@ hdfs_get_options(Oid foreigntableid)
 
 	opt->receive_timeout = 1000 * 300;  /* Default timeout is 300 seconds */
 	opt->connect_timeout = 1000 * 300;  /* Default timeout is 300 seconds */
+	opt->fetch_size = 10000;			/* Default fetch size */
+	opt->log_remote_sql = false;
 
 	/*
 	 * Extract options from FDW objects.
@@ -247,8 +251,14 @@ hdfs_get_options(Oid foreigntableid)
 			}
 		}
 
+		if (strcmp(def->defname, "log_remote_sql") == 0)
+			opt->log_remote_sql = defGetBoolean(def);
+
 		if (strcmp(def->defname, "use_remote_estimate") == 0)
 			opt->use_remote_estimate = defGetBoolean(def);
+
+		if (strcmp(def->defname, "fetch_size") == 0)
+			opt->fetch_size = atoi(defGetString(def));
 
 		if (strcmp(def->defname, "query_timeout") == 0)
 		{

--- a/libhive/Makefile
+++ b/libhive/Makefile
@@ -1,6 +1,7 @@
 .PHONY : clean
 
-CPPFLAGS= -Wno-unused-variable -fPIC -Wall -g -I$(JDK_INCLUDE) -I$(JDK_INCLUDE)/linux/ -Ijdbc
+PG_INC_PATH=$(shell pg_config --includedir-server)
+CPPFLAGS= -Wno-unused-variable -fPIC -Wall -g -I$(PG_INC_PATH) -I$(JDK_INCLUDE) -I$(JDK_INCLUDE)/linux/ -Ijdbc
 LDFLAGS:= $(LDFLAGS) -shared
 
 JDBC =	 jdbc/hiveclient.cpp jdbc/data.cpp

--- a/libhive/jdbc/JDBCType.java
+++ b/libhive/jdbc/JDBCType.java
@@ -1,0 +1,172 @@
+/*-------------------------------------------------------------------------
+ *
+ * JDBCType.java
+ * 		Class to store parameter values
+ *
+ * Copyright (c) 2017, EnterpriseDB Corporation.
+ *
+ * IDENTIFICATION
+ * 		JDBCType.java
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import java.lang.String;
+import java.sql.Date;
+import java.sql.Timestamp;
+
+public class JDBCType
+{
+	private static final int	m_noType = 0;
+
+	private static final int	m_boolType = 1;
+	private static final int	m_shortType = 2;
+	private static final int	m_intType = 3;
+	private static final int	m_longType = 4;
+
+	private static final int	m_doubType = 5;
+	private static final int	m_floatType = 6;
+
+	private static final int	m_stringType = 7;
+	private static final int	m_dateType = 8;
+	private static final int	m_timeType = 9;
+	private static final int	m_stampType = 10;
+
+	private int			m_jdbcType;
+
+	private boolean		m_boolVal;
+	private short		m_shortVal;
+	private int			m_intVal;
+	private long		m_longVal;
+
+	private double		m_doubleVal;
+	private float		m_floatVal;
+
+	private String		m_stringVal;
+	private Date		m_dateVal;
+//	private Time		m_timeVal;
+	private Timestamp	m_stampVal;
+
+	public JDBCType(int typ)
+	{
+		m_jdbcType = typ;
+	}
+
+	public int getType()
+	{
+		if (m_jdbcType < m_boolType || m_jdbcType > m_stampType)
+			return -1;
+		return m_jdbcType;
+	}
+
+	public void setBool(boolean x)
+	{
+		m_boolVal = x;
+		m_jdbcType = m_boolType;
+	}
+
+	public void setShort(short x)
+	{
+		m_shortVal = x;
+		m_jdbcType = m_shortType;
+	}
+
+	public void setInt(int x)
+	{
+		m_intVal = x;
+		m_jdbcType = m_intType;
+	}
+
+	public void setLong(long x)
+	{
+		m_longVal = x;
+		m_jdbcType = m_longType;
+	}
+
+	public void setDoub(double x)
+	{
+		m_doubleVal = x;
+		m_jdbcType = m_doubType;
+	}
+
+	public void setFloat(float x)
+	{
+		m_floatVal = x;
+		m_jdbcType = m_floatType;
+	}
+
+	public void setString(String x)
+	{
+		m_stringVal = x;
+		m_jdbcType = m_stringType;
+	}
+
+	public void setDate(Date x)
+	{
+		m_dateVal = x;
+		m_jdbcType = m_dateType;
+	}
+
+//	public void setTime(Time x)
+//	{
+//		m_timeVal = x;
+//		m_jdbcType = m_timeType;
+//	}
+
+	public void setStamp(Timestamp x)
+	{
+		m_stampVal = x;
+		m_jdbcType = m_stampType;
+	}
+
+
+	public boolean getBool()
+	{
+		return m_boolVal;
+	}
+
+	public short getShort()
+	{
+		return m_shortVal;
+	}
+
+	public int getInt()
+	{
+		return m_intVal;
+	}
+
+	public long getLong()
+	{
+		return m_longVal;
+	}
+
+	public double getDoub()
+	{
+		return m_doubleVal;
+	}
+
+	public float getFloat()
+	{
+		return m_floatVal;
+	}
+
+	public String getString()
+	{
+		return m_stringVal;
+	}
+
+	public Date getDate()
+	{
+		return m_dateVal;
+	}
+
+//	public Time getTime()
+//	{
+//		return m_timeVal;
+//	}
+
+	public Timestamp getStamp()
+	{
+		return m_stampVal;
+	}
+}

--- a/libhive/jdbc/hiveclient.h
+++ b/libhive/jdbc/hiveclient.h
@@ -149,6 +149,49 @@ int DBCloseAllConnections();
 int DBExecute(int con_index, const char* query, int maxRows, char **errBuf);
 
 /**
+ * @brief Prepare a query for execution later.
+ *
+ * Prepares a query on a Hive connection.
+ *
+ * @see DBExecutePrepared()
+ *
+ * @param index          Index of the result set object to use.
+ * @param query          The HQL query string to be prepared.
+ * @param maxRows        Max number of rows to buffer in the result set for the query results
+ * @param errBuf         Buffer to receive an error message if any.
+ *                       It receives a copy of the pointer to the already allocated
+ *                       memory that the caller does not need to worry about.
+ *
+ * @return Any negative value indicates an error, 0 means success.
+ *         Error messages will be stored in errBuf.
+ */
+int DBPrepare(int con_index, const char* query, int maxRows, char **errBuf);
+
+/**
+ * @brief Execute a prepared query.
+ *
+ * Executes a query on a Hive connection and associates a result set with it.
+ * There is no need for this function to return result set to the caller.
+ * The result set can be held by the underlying java object
+ * and there is no need to return it to the caller.
+ * This design change simplifies and reduces the amount of coding we have to do
+ * while trying to write the JNI code to access Java class functions from C++.
+ * Caller is responsible for deallocating the result set object by
+ * calling DBCloseResultSet.
+ *
+ * @see DBCloseResultSet()
+ *
+ * @param index          Index of the result set object to use.
+ * @param errBuf         Buffer to receive an error message if any.
+ *                       It receives a copy of the pointer to the already allocated
+ *                       memory that the caller does not need to worry about.
+ *
+ * @return Any negative value indicates an error, 0 means success.
+ *         Error messages will be stored in errBuf.
+ */
+int DBExecutePrepared(int con_index, char **errBuf);
+
+/**
  * @brief Execute a utility query.
  *
  * Utility queries are not supposed to return any result set
@@ -235,6 +278,25 @@ int DBGetColumnCount(int con_index, char **errBuf);
  *         Error messages will be stored in errBuf.
  */
 int DBGetFieldAsCString(int con_index, int columnIdx, char **buffer, char **errBuf);
+
+
+/**
+ * @brief Bind a value to a parameter in a parameterized query
+ *
+ * The function keeps track of the parameter number itself.
+ *
+ * @param index          Index of the result set object to use.
+ * @param type           PG Type of the parameter.
+ * @param value          PG value of the parameter.
+ * @param isnull         Is value to be bound a null.
+ * @param errBuf         Buffer to receive an error message if any.
+ *                       It receives a copy of the pointer to the already allocated
+ *                       memory that the caller does not need to worry about.
+ *
+ * @return Any negative value indicates an error, 0 means success.
+ *         Error messages will be stored in errBuf.
+ */
+int DBBindVar(int con_index, Oid type, void *value, bool *isnull, char **errBuf);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
After fixing the issues all the queries except the ones
containing correlated sub queries run fine.
Queries 9, 17 and 20 are examples of correlated sub queries
and these queries do not return after hours of waiting
with a couple of GBs of data.

The patch removes the following issues:

1. In each query execution FDW used to issue a DESC table_name
   statement to the hive server. This patch removes the need
   for issuing this command and hence removes all the code
   associated with it.
   Previously the FDW needed column type while retrieving
   its value. There is no need of column type any more.
   Hence the need of this round trip is eliminated.
   This enhances the performance as well cleans up the code.

2. Adds support for pushing down parametrized WHERE clauses.
   The query execution is broken down into three steps to make
   this possible: PREPARE, BIND and EXECUTE.
   While rescanning the new parameters are bound and the same
   prepared query is executed again.
   NULL values of bound parameters are not supported.
   JDBC Type Time is also not supported.
   The following parameter types are supported:
    INT2OID
    INT4OID
    INT8OID
    FLOAT4OID
    FLOAT8OID
    NUMERICOID
    BOOLOID
    BPCHAROID
    VARCHAROID
    TEXTOID
    JSONOID
    NAMEOID
    DATEOID
    TIMEOID
    TIMESTAMPOID
    TIMESTAMPTZOID
    BITOID

3. The costing system of FDW was not correct and query costs were
   coming up as negative values. The patch corrects the costing
   mechanism. The patch increases the ForeignScan node costs
   to make sure that the planner inserts materialize nodes at
   appropriate places in the plan tree to avoid UN-necessary
   rescans. This is a major improvement and makes most of the
   TPC-H queries execute in a reasonable time frame.

4. The option use_remote_estimates was not working.
   The patch corrects the syntax error in the remote query.
   Also it was using count(*) to get the rows in the remote table.
   The execution of a count(*) on the hive table took some 4-5 seconds
   and hence enabling remote estimates was making queries slow.
   This patch changes the FDW to use EXPLAIN select * from remote_table.
   While this works only if the hive tables are analysed i.e. stats are
   updated, this technique is very fast as compared to count(*) and
   does not slow down the whole query execution.
   The minimum row count that a remote estimate can return is 1000.

5. Adds a new option while creating the remote server: fetch_size
   Default value is 10,000. For example:
    CREATE SERVER hdfs_server FOREIGN DATA WRAPPER hdfs_fdw
    OPTIONS (host '54.90.191.116',
        use_remote_estimate 'true',
        fetch_size '100000');
   The user specified value is used as parameter to the JDBC API
   setFetchSize(fetch_size)

6. Adds a new option while creating the remote server: log_remote_sql
   Default value is false. If set to true it logs the following:
   - All the SQL's sent to the remote hive server.
   - The number of times a remote scan is repeated i.e. rescanned.

7. Adds a IS_DEBUG compile time option to add debug messages in log.

8. Removes UN-necessary members in HDFSFdwScanState structure.

TODO Items:
1. For accurate row counts we should append where clauses
   with the EXPLAIN SELECT statement, but if where clause
   is parametrized we should handle it the way pg fdw does.

2. Add support for NULL values as parameters

3. Support JDBC Time type as a parameter.

4. Specific test cases of each bound parameter type are to be added.