### PR TITLE
Fix for issue #52 - connection string differences between hive and spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ While creating the foreign server object for HDFS FDW the following can be speci
   
     * `host`: IP Address or hostname of the Hive Thrift Server OR Spark Thrift Server. Defaults to `127.0.0.1`
     * `port`: Port number of the Hive Thrift Server OR Spark Thrift Server. Defaults to `10000`
-    * `client_type`:  hiveserver2 or spark. Hive and Spark both support HiveQL and are compatible but ANALYZE command behaves differently. Default is hiveserver2 and will work with Spark too except the ANALYZE command.
+    * `client_type`:  hiveserver2 or spark. Hive and Spark both support HiveQL and are compatible but there are few differences like the behaviour of ANALYZE command and connection string for the NOSASL case.
     * `auth_type`:  NOSASL or LDAP. Specify which authentication type is required while connecting to the Hive or Spark server. Default is unspecified and the FDW uses the username option in the user mapping to infer the auth_type. If the username is empty or not specified it uses NOSASL otherwise it uses LDAP.
     * `connect_timeout`:  Connection timeout, default value is 300 seconds.
     * `query_timeout`:  Query timeout is not supported by the Hive JDBC driver.
@@ -259,7 +259,7 @@ Using HDFS FDW with Apache Spark on top of Hadoop
         OPTIONS (dbname 'testdb', table_name 'my_names_tab');
     ```
   
-Please note that we are using the same port while creating foreign server because Spark Thrift Server is compatible with Hive Thrift Server. Applications using Hiveserver2 would work with Spark except for the ANALYZE command. It is better to use ALTER SERVER and change the client_type option if Hive is to be replaced with Spark.
+Please note that we are using the same port while creating foreign server because Spark Thrift Server is compatible with Hive Thrift Server. Applications using Hiveserver2 would work with Spark except for the behaviour of ANALYZE command and the connection string in case of NOSASL. It is better to use ALTER SERVER and change the client_type option if Hive is to be replaced with Spark.
 
 5. Download & install Apache Spark in local mode
 

--- a/hdfs_connection.c
+++ b/hdfs_connection.c
@@ -38,6 +38,7 @@ hdfs_get_connection(ForeignServer *server, UserMapping *user, hdfs_opt *opt)
 							opt->connect_timeout,
 							opt->receive_timeout,
 							opt->auth_type,
+							opt->client_type,
 							&err_buf);
 	if (conn < 0)
 		ereport(ERROR,

--- a/libhive/jdbc/HiveJdbcClient.java
+++ b/libhive/jdbc/HiveJdbcClient.java
@@ -40,6 +40,9 @@ public class HiveJdbcClient
 	private static final int	m_authTypeNoSasl = 1;
 	private static final int	m_authTypeLDAP = 2;
 
+	private static final int	m_clientTypeHive = 0;
+	private static final int	m_clientTypeSpark = 1;
+
 	private int					m_queryTimeout = 0;
 	private boolean				m_isDebug = false;
 	private int					m_nestingLimit = 100;
@@ -77,7 +80,7 @@ public class HiveJdbcClient
 	public int DBOpenConnection(String host, int port, String databaseName,
 								String userName, String password,
 								int connectTimeout, int receiveTimeout,
-								int authType, MsgBuf errBuf)
+								int authType, int clientType, MsgBuf errBuf)
 	{
 		int index;
 		String hst;
@@ -182,7 +185,9 @@ public class HiveJdbcClient
 				case m_authTypeUnspecified:
 					if (userName == null || userName.equals(""))
 					{
-						conURL += ";auth=noSasl";
+						if (clientType == m_clientTypeHive)
+							conURL += ";auth=noSasl";
+
 						m_hdfsConnection[index] = DriverManager.getConnection(conURL, "userName", "password");
 					}
 					else
@@ -192,7 +197,9 @@ public class HiveJdbcClient
 					break;
 
 				case m_authTypeNoSasl:
-					conURL += ";auth=noSasl";
+					if (clientType == m_clientTypeHive)
+						conURL += ";auth=noSasl";
+
 					if (userName == null || userName.equals(""))
 					{
 						errBuf.catVal("ERROR : A valid user name is required");
@@ -221,7 +228,9 @@ public class HiveJdbcClient
 				default:
 					if (userName == null || userName.equals(""))
 					{
-						conURL += ";auth=noSasl";
+						if (clientType == m_clientTypeHive)
+							conURL += ";auth=noSasl";
+
 						m_hdfsConnection[index] = DriverManager.getConnection(conURL, "userName", "password");
 					}
 					else

--- a/libhive/jdbc/hiveclient.cpp
+++ b/libhive/jdbc/hiveclient.cpp
@@ -205,7 +205,7 @@ int Initialize()
 	}
 
 	g_DBOpenConnection = g_jni->GetMethodID(g_clsJdbcClient, "DBOpenConnection",
-				"(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILMsgBuf;)I");
+				"(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIILMsgBuf;)I");
 	if (g_DBOpenConnection == NULL)
 	{
 		g_jvm->DestroyJavaVM();
@@ -397,7 +397,7 @@ int Destroy()
 int DBOpenConnection(char *host, int port, char *databaseName,
 					char *username, char *password,
 					int connectTimeout, int receiveTimeout,
-					AUTH_TYPE auth_type, char **errBuf)
+					AUTH_TYPE auth_type, CLIENT_TYPE client_type, char **errBuf)
 {
 	int rc;
 	jstring rv;
@@ -419,6 +419,7 @@ int DBOpenConnection(char *host, int port, char *databaseName,
 							connectTimeout,
 							receiveTimeout,
 							auth_type,
+							client_type,
 							g_objMsgBuf);
 
 	rv = (jstring)g_jni->CallObjectMethod(g_objMsgBuf, g_getVal);

--- a/libhive/jdbc/hiveclient.h
+++ b/libhive/jdbc/hiveclient.h
@@ -93,7 +93,7 @@ int Destroy(void);
 int DBOpenConnection(char *host, int port, char *databaseName,
 					char *username, char *password,
 					int connectTimeout, int receiveTimeout,
-					AUTH_TYPE auth_type, char **errBuf);
+					AUTH_TYPE auth_type, CLIENT_TYPE client_type, char **errBuf);
 
 /**
  * @brief Disconnect from a Hive database.


### PR DESCRIPTION
RM 42710, When tested with spark 2.1.1, it does not allow client
connection when auth=noSasl is supplied in the connection string.
Hive on the other hand needs auth=noSasl.
To accomodate this difference in the connection string between
hive and spark hdfs_fdw uses client_type.